### PR TITLE
TIL 25.05.23 - Poll Phase

### DIFF
--- a/node-js/nodejs-poll-phase/file-io.mjs
+++ b/node-js/nodejs-poll-phase/file-io.mjs
@@ -1,0 +1,15 @@
+import fs from "fs";
+
+console.log("Start reading file..."); // global e.c.
+
+const readFileCallback = (err, data) => {
+    console.log(`readFileCallback() : ${data}`);
+};
+
+const file = "./test.txt";
+
+fs.readFile(file, readFileCallback);
+
+for (let i = 0; i < 1e8; i++);
+
+console.log("End reading file...");

--- a/node-js/nodejs-poll-phase/socket-io.mjs
+++ b/node-js/nodejs-poll-phase/socket-io.mjs
@@ -1,0 +1,17 @@
+import net from "net";
+
+console.log("start");
+
+// net.Socket() 생성 시 libuv를 통해 커널에 소켓 생성 요청
+// libuv는 epoll 등 이벤트 감시자를 내부적으로 관리함
+const success = new net.Socket();
+
+// connect() 호출 시 TCP handshake는 OS 커널에서 처리되고,
+// libuv의 poll phase에서 연결 완료 이벤트를 감지함
+success.connect(80, "www.google.com", () => {
+    console.log("Connected to server");
+});
+
+success.on("error", (err) => {
+    console.error("Socket error:", err);
+});

--- a/node-js/nodejs-poll-phase/test.txt
+++ b/node-js/nodejs-poll-phase/test.txt
@@ -1,0 +1,1 @@
+hello nodejs


### PR DESCRIPTION
## Poll Phase
- idle, prepare phase
  - linux 에서 `epoll` 인스턴스에 등록된 file descriptor 에 이벤트가 발생하면 nodejs (libuv) 에 알려주는 방식으로 비동기 매커니즘이 동작함
  - nodejs 에서 비동기 작업 발생 -> libuv 는 커널에 epoll 관련 시스템콜을 위임함
  - libuv 는 커널에 `epoll_create()` , `epoll_ctl()` 을 통해서 파일 디스크립터를 epoll 인스턴스에 등록하는 작업을 위임
  - tcp 소켓 connection 을 예로들면 `socket()` 을 통한 소켓 생성 -> 생성된 `socket()` 의 file descriptor 를 epoll 인스턴스에 등록

- poll phase
  - `epoll_wait()` 을 통해서 epoll 인스턴스에 등록된 파일 디스크립터 / connection object 에서 이벤트 발생까지 기다림
  - 이게 원래 블로킹되는데, nodejs 는 timeout 을 설정해둠
  - A) timeout 이 만료되거나 , B) epoll 에 등록된 file descriptor 에서 이벤트 발생시 -> 블로킹 해제하고 이벤트 반환
  - 반환된 이벤트는 libuv 에 이벤트결과를 알려주고, libuv 는 nodejs 에 처리할 콜백이나 promise 가 있다고 알려줌

## epoll_wait 의 블로킹 특성을 어떻게 nodejs 가 non blocking 으로 동작하도록 하는가
- libuv 가 `epoll_wait()` 를 호출시 timout 을 인자로 전달
  - 매우 짧거나 다음 타이머 callback 실행까지 시간이 될수도 있음
  - 따라서, `epoll_wait` 이 블로킹 되더라도 메인 스레드는 IO 가 무한 대기하는것이 아니라 최대 얼마동안만 대기하고 이후에는 당므 단계로 이동해서 다른 콜백을 처리하도록 함
 - `epoll_wait()` 이 타임아웃이 되든 이벤트 발생해서 반환되는 nodejs 이벤트 루프는 `epoll_wait()` 호출에서 벗어나고 다음 event loop 단계로 진행함
 - 이렇게 계속 이벤트루프는 돈다..