### PR TITLE
TIL 25.06.02 - require vs import

### DIFF
--- a/node-js/nodejs-process-nexttick/next-tick-promise.mjs
+++ b/node-js/nodejs-process-nexttick/next-tick-promise.mjs
@@ -1,0 +1,14 @@
+function promise(cb) {
+    return new Promise((resolve, reject) => {
+        resolve(cb);
+    });
+}
+
+function nextTickPromise(cb) {
+    process.nextTick(cb);
+}
+
+// nextTickPromise(() => console.log("This is a nextTick callback"));
+promise(() => console.log("This is a promise callback"));
+
+console.log("Global E.C. ends here");

--- a/node-js/nodejs-require-import/import.js
+++ b/node-js/nodejs-require-import/import.js
@@ -1,0 +1,27 @@
+import moduleA from "./module-a.js";
+
+const condition = true;
+
+if (condition) {
+    import("./module-b.js").then((module) => {
+        console.log("Module B loaded");
+    });
+} else {
+    import("./module-c.js").then((module) => {
+        console.log("Module C loaded");
+    });
+}
+
+setTimeout(() => console.log("Timers Phase"), 0);
+setImmediate(() => console.log("Check Phase"));
+
+console.log("Global E.C. END");
+
+`
+Module A
+Global E.C. END
+Check Phase
+Module B
+Module B loaded
+Timers Phase
+`;

--- a/node-js/nodejs-require-import/mjs.mjs
+++ b/node-js/nodejs-require-import/mjs.mjs
@@ -1,0 +1,5 @@
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+
+require("./module-c.js");

--- a/node-js/nodejs-require-import/module-a.js
+++ b/node-js/nodejs-require-import/module-a.js
@@ -1,0 +1,1 @@
+console.log("Module A");

--- a/node-js/nodejs-require-import/module-b.js
+++ b/node-js/nodejs-require-import/module-b.js
@@ -1,0 +1,1 @@
+console.log("Module B");

--- a/node-js/nodejs-require-import/module-c.js
+++ b/node-js/nodejs-require-import/module-c.js
@@ -1,0 +1,1 @@
+console.log("Module C");

--- a/node-js/nodejs-require-import/require.js
+++ b/node-js/nodejs-require-import/require.js
@@ -1,0 +1,22 @@
+const moduleC = require("./module-c.js");
+
+const condition = true;
+
+if (condition) {
+    require("./module-a.js");
+} else {
+    require("./module-b.js");
+}
+
+setTimeout(() => console.log("Timers Phase"), 0);
+setImmediate(() => console.log("Check Phase"));
+
+console.log("Global E.C. END");
+
+`
+Module C
+Module A
+Global E.C. END
+Timers Phase
+Check Phase
+`;


### PR DESCRIPTION
- `require()`
  - common js (.js 확장자에서만 동작)
  - global e.c. creation phase 에서 모듈 로드
  - 동기적으로 모듈 로드

- `import()`
  - .js, .mjs 확장자에서 동작
  - global e.c. execution phase 에서 모듈 로드
  - 비동기적으로 모듈 로드, promise 반환
  - poll phase 에서 동작
  - 실제 import() 호출시점과 실제 모듈을 파일시스템으로 부터 읽고 파싱, 실행은 poll phase 에서됨
  - 즉, 호출시점과 실제 모듈 로드시점은 서로다를수 있음. 모듈 로드와 스크립트 실행 phase 가 다름

- `import A from B`
  - global e.c. creation phase 이전 스크립트 파싱 단계에서 실행
  - 호이스팅되어 항상 최초로 모듈 로드
  

- mjs 에서 require 쓰는법

```js
import { createRequire } from "module";
const require = createRequire(import.meta.url);
require("./my-module.js");
```